### PR TITLE
Leverage Font Smoothing

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -432,7 +432,9 @@ export default {
 				color: colors.white,
 				fontFamily: fontFamilies.scorewin,
 				fontSize: fontSizes.md,
-				textTransform: 'none'
+				textTransform: 'none',
+				'-webkit-font-smoothing': 'antialiased',
+				'moz-osx-font-smoothing': 'grayscale'
 			},
 			target: '_blank'
 		}


### PR DESCRIPTION
https://github.com/stephencorwin/stephencorwin.me/issues/7

Upon further investigation, only the ScoreWin logo required antialiasing.